### PR TITLE
CI integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2 # use CircleCI 2.0
 jobs: # a collection of steps
   build: # runs not using Workflows must have a `build` job as entry point
-    working_directory: ~/ # directory where steps will run
+    working_directory: ~/qs-to-json # directory where steps will run
     docker: # run the steps with Docker
       - image: circleci/node:8.10 # ...with this image as the primary container; this is where all `steps` will run
     steps: # a collection of executable commands


### PR DESCRIPTION
This changeset helps to integrate the project with CircleCI for CI.

This helps when we create pull request or push into some other branch, all test will automatically run and result will be reported back to us.

We will disable direct push to master and enable this branch protection